### PR TITLE
wip: streaming data demo

### DIFF
--- a/src/pages/LiveDemo.tsx
+++ b/src/pages/LiveDemo.tsx
@@ -1,0 +1,45 @@
+import React, { FC, useEffect, useState } from 'react';
+import { AppRootProps, DataFrame, DataQueryResponse, Field, LiveChannelScope, Vector } from '@grafana/data';
+import { getGrafanaLiveSrv, config } from '@grafana/runtime';
+import { HorizontalGroup, Spinner } from '@grafana/ui';
+
+export const LiveDemo: FC<AppRootProps> = ({ query, path, meta }) => {
+  const [data, setData] = useState<DataQueryResponse>();
+
+  useEffect(() => {
+    const uid = config.datasources['Sensetif Datasource']?.uid;
+    if (!uid) {
+      console.warn('sensetif datasource not found');
+      return;
+    }
+
+    const stream = getGrafanaLiveSrv().getDataStream({
+      addr: {
+        scope: LiveChannelScope.DataSource,
+        namespace: uid,
+        path: 'sensetif-path-1',
+      },
+    });
+
+    stream.subscribe(setData);
+  }, []);
+
+  console.log(data);
+
+  if (!data?.data?.[0]) {
+    return <Spinner />;
+  }
+
+  return (
+    <>
+      <HorizontalGroup>
+        <pre>{JSON.stringify(getLastField((data.data[0] as DataFrame).fields, 'Time'), null, " '")}</pre>
+        <pre>{JSON.stringify(getLastField((data.data[0] as DataFrame).fields, 'Value'), null, " '")}</pre>
+      </HorizontalGroup>
+    </>
+  );
+};
+
+function getLastField(fields: Array<Field<any, Vector<any>>>, name: string): Field<any, Vector<any>> | undefined {
+  return fields.filter((f) => f.name === name).pop();
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -12,6 +12,7 @@ import { EditDatapoint } from './EditDatapoint';
 import { Payments } from './Payments';
 import { Succeeded } from './Succeeded';
 import { Cancelled } from './Cancelled';
+import { LiveDemo } from './LiveDemo';
 
 export type PageDefinition = {
   component: React.FC<AppRootProps>;
@@ -83,6 +84,13 @@ export const EditDatapointPage: PageDefinition = {
   text: ' Edit Datapoint',
 };
 
+export const LiveDemoPage: PageDefinition = {
+  component: LiveDemo,
+  icon: 'fa rocket',
+  id: 'live-demo',
+  text: ' Live Demo',
+};
+
 export const PlansPage: PageDefinition = {
   component: Plans,
   icon: 'fa fa-file-invoice-dollar',
@@ -127,3 +135,5 @@ pages[EditDatapointPage.id] = EditDatapointPage;
 pages[PlansPage.id] = PlansPage;
 pages[SucceededPage.id] = SucceededPage;
 pages[CancelledPage.id] = CancelledPage;
+
+pages[LiveDemoPage.id] = LiveDemoPage;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -47,6 +47,13 @@
       "path": "/a/sensetif-app?tab=plans",
       "role": "Admin",
       "addToNav": true
+    },
+    {
+      "type": "page",
+      "name": "Live Demo",
+      "path": "/a/sensetif-app?tab=live-demo",
+      "role": "Admin",
+      "addToNav": true
     }
   ],
   "dependencies": {


### PR DESCRIPTION
pls do not merge; total playground

datasource named `Sensetif Datasource` needs to be added.
demo available at `/a/sensetif-app?tab=live-demo` renders data from backend datasource streaming handler